### PR TITLE
feat: integrate MapStruct and Lombok for DTO mapping

### DIFF
--- a/BookPlace/BookPlace/pom.xml
+++ b/BookPlace/BookPlace/pom.xml
@@ -15,6 +15,9 @@
 	<description>e-commerce Bookplace</description>
 	<properties>
 		<java.version>21</java.version>
+		<org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
+		<org.projectlombok.version>1.18.30</org.projectlombok.version>
+		<lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -33,6 +36,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<version>${org.projectlombok.version}</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>
@@ -62,16 +66,6 @@
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-oauth2-authorization-server</artifactId>
 		</dependency>
-			<dependency>
-				<groupId>org.projectlombok</groupId>
-				<artifactId>lombok</artifactId>
-				<version>1.18.32</version>
-				<scope>provided</scope>
-			</dependency>
-		<dependency>
-			<groupId>com.mercadopago</groupId>
-			<artifactId>sdk-java</artifactId>
-		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
@@ -85,6 +79,14 @@
 			<artifactId>junit-jupiter-api</artifactId>
 		</dependency>
 
+		<!-- INICIO /  Mapstruct -->
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>1.5.5.Final</version>
+		</dependency>
+		<!-- FIM /  Mapstruct -->
+
 	</dependencies>
 
 	<build>
@@ -97,6 +99,30 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.11.0</version>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>${org.mapstruct.version}</version>
+						</path>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>${org.projectlombok.version}</version>
+						</path>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok-mapstruct-binding</artifactId>
+							<version>${lombok-mapstruct-binding.version}</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/BookPlace/BookPlace/src/main/java/com/dev/BookPlace/dto/AddressDTO.java
+++ b/BookPlace/BookPlace/src/main/java/com/dev/BookPlace/dto/AddressDTO.java
@@ -23,6 +23,7 @@ public class AddressDTO {
     private String country;
     private String postalCode;
     private Boolean main;
+    private String nickname;
 
     public AddressDTO(Address addressEntity) {
         id = addressEntity.getId();

--- a/BookPlace/BookPlace/src/main/java/com/dev/BookPlace/dto/OrderDTO.java
+++ b/BookPlace/BookPlace/src/main/java/com/dev/BookPlace/dto/OrderDTO.java
@@ -17,7 +17,6 @@ import java.util.List;
 @NoArgsConstructor
 @Getter
 @Setter
-
 public class OrderDTO {
 
 	private Long id;

--- a/BookPlace/BookPlace/src/main/java/com/dev/BookPlace/entities/bookplace/entities/Address.java
+++ b/BookPlace/BookPlace/src/main/java/com/dev/BookPlace/entities/bookplace/entities/Address.java
@@ -27,6 +27,7 @@ public class Address{
     private String country;
     private String postalCode;
     private Boolean main;
+    private String apelido;
 
     @ManyToOne
     @JoinColumn(name = "user_id")

--- a/BookPlace/BookPlace/src/main/java/com/dev/BookPlace/entities/bookplace/entities/User.java
+++ b/BookPlace/BookPlace/src/main/java/com/dev/BookPlace/entities/bookplace/entities/User.java
@@ -9,7 +9,6 @@ import java.time.LocalDate;
 import java.util.*;
 
 @SuppressWarnings("serial")
-
 @Entity
 @Table(name = "tb_user")
 public class User implements UserDetails {

--- a/BookPlace/BookPlace/src/main/java/com/dev/BookPlace/mappers/AddressDTOMapper.java
+++ b/BookPlace/BookPlace/src/main/java/com/dev/BookPlace/mappers/AddressDTOMapper.java
@@ -1,0 +1,15 @@
+package com.dev.BookPlace.mappers;
+
+import com.dev.BookPlace.dto.AddressDTO;
+import com.dev.BookPlace.entities.bookplace.entities.Address;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel="spring")
+public interface AddressDTOMapper {
+    @Mapping(source = "apelido", target = "nickname")
+    AddressDTO toAddressDTO(Address address);
+
+    @Mapping(source = "nickname", target = "apelido")
+    Address toAddress(AddressDTO addressDTO);
+}

--- a/BookPlace/BookPlace/src/main/java/com/dev/BookPlace/mappers/RoleDTOMapper.java
+++ b/BookPlace/BookPlace/src/main/java/com/dev/BookPlace/mappers/RoleDTOMapper.java
@@ -1,0 +1,12 @@
+package com.dev.BookPlace.mappers;
+
+import com.dev.BookPlace.dto.RoleDTO;
+import com.dev.BookPlace.entities.bookplace.entities.Role;
+import org.mapstruct.Mapper;
+
+import java.util.List;
+
+@Mapper(componentModel="spring")
+public interface RoleDTOMapper {
+    List<RoleDTO> toRoleDTOList(List<Role> roleList);
+}

--- a/BookPlace/BookPlace/src/main/java/com/dev/BookPlace/mappers/UserDTOMapper.java
+++ b/BookPlace/BookPlace/src/main/java/com/dev/BookPlace/mappers/UserDTOMapper.java
@@ -1,0 +1,10 @@
+package com.dev.BookPlace.mappers;
+
+import com.dev.BookPlace.dto.UserDTO;
+import com.dev.BookPlace.entities.bookplace.entities.User;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel="spring")
+public interface UserDTOMapper {
+    UserDTO toUserDTO(User user);
+}

--- a/BookPlace/BookPlace/src/main/java/com/dev/BookPlace/services/AddressService.java
+++ b/BookPlace/BookPlace/src/main/java/com/dev/BookPlace/services/AddressService.java
@@ -3,12 +3,13 @@ package com.dev.BookPlace.services;
 import com.dev.BookPlace.dto.AddressDTO;
 import com.dev.BookPlace.entities.bookplace.entities.Address;
 import com.dev.BookPlace.entities.bookplace.entities.User;
+import com.dev.BookPlace.mappers.AddressDTOMapper;
 import com.dev.BookPlace.repositories.AddressRepository;
 import com.dev.BookPlace.repositories.UserRepository;
 import com.dev.BookPlace.services.exceptions.DatabaseException;
 import com.dev.BookPlace.services.exceptions.ResourceNotFoundException;
 import jakarta.persistence.EntityNotFoundException;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
@@ -16,18 +17,16 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
+@RequiredArgsConstructor
 @Service
 public class AddressService {
 
-    @Autowired
-    private AddressRepository addressRepository;
-
-    @Autowired
-    private UserRepository userRepository;
-
-    @Autowired
-    private UserService userService;
+    private final AddressRepository addressRepository;
+    private final UserRepository userRepository;
+    private final UserService userService;
+    private final AddressDTOMapper addressDTOMapper;
 
     @Transactional(readOnly = true)
     public List<AddressDTO> findAllAddressList() {
@@ -38,8 +37,7 @@ public class AddressService {
 
     @Transactional
     public AddressDTO insertAddress(AddressDTO dto) {
-        Address entity = new Address();
-        copyDtoToEntity(dto, entity);
+        Address entity = addressDTOMapper.toAddress(dto);
         entity = addressRepository.save(entity);
         return new AddressDTO(entity);
     }
@@ -51,7 +49,7 @@ public class AddressService {
             Address entity = addressRepository.getReferenceById(id);
             Long userId = userService.authenticated().getId();
 
-            if (userId == entity.getUser().getId()) {
+            if (Objects.equals(userId, entity.getUser().getId())) {
                 copyDtoToEntity(dto, entity);
                 entity = addressRepository.save(entity);
                 return new AddressDTO(entity);


### PR DESCRIPTION
- Add MapStruct and Lombok dependencies in pom.xml for DTO mapping and code simplification.
- Implement AddressDTOMapper using MapStruct for Address entity and DTO conversion.
- Refactor AddressService to use AddressDTOMapper for DTO to entity conversion.
- Introduce nickname field in AddressDTO and corresponding apelido field in Address entity for mapping demonstration.
- Setup maven-compiler-plugin with annotationProcessorPaths for MapStruct and Lombok processing.
- Remove unused imports and annotations in AddressService.
- Code formatting adjustments in User, OrderDTO, and User entities.