### PR TITLE
refactor(config): renomear pacotes de Config para config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,196 @@
 /.metadata/
+
+# Created by https://www.toptal.com/developers/gitignore/api/java,intellij+all,eclipse,netbeans
+# Edit at https://www.toptal.com/developers/gitignore?templates=java,intellij+all,eclipse,netbeans
+
+### Eclipse ###
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# CDT- autotools
+.autotools
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Annotation Processing
+.apt_generated/
+.apt_generated_test/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+
+# Uncomment this line if you wish to ignore the project description file.
+# Typically, this file would be tracked if it contains build/dependency configurations:
+#.project
+
+### Eclipse Patch ###
+# Spring Boot Tooling
+.sts4-cache/
+
+### Intellij+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
+
+.idea/*
+
+!.idea/codeStyles
+!.idea/runConfigurations
+
+### Java ###
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+### NetBeans ###
+**/nbproject/private/
+**/nbproject/Makefile-*.mk
+**/nbproject/Package-*.bash
+build/
+nbbuild/
+dist/
+nbdist/
+.nb-gradle/
+
+# End of https://www.toptal.com/developers/gitignore/api/java,intellij+all,eclipse,netbeans

--- a/BookPlace/BookPlace/src/main/java/com/dev/BookPlace/config/AppConfig.java
+++ b/BookPlace/BookPlace/src/main/java/com/dev/BookPlace/config/AppConfig.java
@@ -1,4 +1,4 @@
-package com.dev.BookPlace.Config;
+package com.dev.BookPlace.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/BookPlace/BookPlace/src/main/java/com/dev/BookPlace/config/AuthorizationServerConfig.java
+++ b/BookPlace/BookPlace/src/main/java/com/dev/BookPlace/config/AuthorizationServerConfig.java
@@ -1,4 +1,4 @@
-package com.dev.BookPlace.Config;
+package com.dev.BookPlace.config;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;

--- a/BookPlace/BookPlace/src/main/java/com/dev/BookPlace/config/ResourceServerConfig.java
+++ b/BookPlace/BookPlace/src/main/java/com/dev/BookPlace/config/ResourceServerConfig.java
@@ -1,4 +1,4 @@
-package com.dev.BookPlace.Config;
+package com.dev.BookPlace.config;
 
 import java.util.Arrays;
 


### PR DESCRIPTION
- Renomeia o pacote `com.dev.BookPlace.Config` para `com.dev.BookPlace.config` nos arquivos:
  - AppConfig.java
  - AuthorizationServerConfig.java
  - ResourceServerConfig.java
- Atualiza o .gitignore para incluir configurações específicas de IDEs e ferramentas de build.

Motivação:
- Seguir a convenção de nomenclatura de pacotes em letras minúsculas.
- Melhorar a organização e consistência do código.